### PR TITLE
Improve update logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,19 @@
 [![Releases](https://img.shields.io/github/v/release/Dwolla/certificate-validator?color=blue)](https://github.com/Dwolla/certificate-validator/releases)
 [![MIT License](https://img.shields.io/github/license/Dwolla/certificate-validator?color=blue)](https://github.com/Dwolla/certificate-validator/blob/master/LICENSE)
 
-Certificate Validator is an AWS CloudFormation custom resource which facilitates certificate validation via DNS.
+Certificate Validator is an AWS CloudFormation custom resource which facilitates AWS Certificate Manager (ACM) certificate validation via DNS.
 
 ## Overview
 
 Certificate Validator solves a common problem:
 
-> *AWS CloudFormation does not provide a means for automatically validating certificates.*
+>*AWS CloudFormation does not provide a means for automatically validating AWS Certificate Manager (ACM) certificates.*
+
+From the [`AWS::CertificateManager::Certificate`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html) documentation:
+
+>**Important**
+>
+>When you use the `AWS::CertificateManager::Certificate` resource in an AWS CloudFormation stack, the stack will remain in the `CREATE_IN_PROGRESS` state. Further stack operations will be delayed until you validate the certificate request, either by acting upon the instructions in the validation email, or by adding a CNAME record to your DNS configuration.
 
 ## Validating a certificate with DNS
 

--- a/certificate_validator/certificate_validator/api.py
+++ b/certificate_validator/certificate_validator/api.py
@@ -9,7 +9,7 @@ import botocore
 
 class ValidationMethod(str, Enum):
     """
-    ValidationMethod of a Request Certificate request.
+    ValidationMethod of a RequestCertificate request.
 
     The ValidationMethod is the method you want to use to validate that you own
     or control the domain associated with a public certificate. You can

--- a/certificate_validator/certificate_validator/provider.py
+++ b/certificate_validator/certificate_validator/provider.py
@@ -449,6 +449,18 @@ class Provider():
         within the template. Therefore, custom resource code doesn't have to
         detect changes because it knows that its properties have changed when
         Update is being called.
+
+        *Replacing a Custom Resource During an Update*
+
+        You can update custom resources that require a replacement of the
+        underlying physical resource. When you update a custom resource in an
+        AWS CloudFormation template, AWS CloudFormation sends an update request
+        to that custom resource. If a custom resource requires a replacement,
+        the new custom resource must send a response with the new physical ID.
+        When AWS CloudFormation receives the response, it compares the
+        PhysicalResourceId between the old and new custom resources. If they
+        are different, AWS CloudFormation recognizes the update as a
+        replacement and sends a delete request to the old resource.
         """
         raise NotImplementedError
 

--- a/certificate_validator/tests/base.py
+++ b/certificate_validator/tests/base.py
@@ -197,13 +197,15 @@ class CertificateValidatorBaseTestCase(AWSBaseTestCase, ProviderBaseTestCase):
             'PhysicalResourceId': 'physical_resource_id',
             'ResourceProperties': {
                 'ServiceToken': 'service_token',
-                'CertificateArn': 'arn:aws:acm:us-east-1:123:certificate/1337',
+                'CertificateArn': 'arn:aws:acm:us-east-1:123:certificate/1',
             },
             'OldResourceProperties': {
-                'ServiceToken': 'service_token'
+                'ServiceToken': 'service_token',
+                'CertificateArn': 'arn:aws:acm:us-east-1:123:certificate/0',
             }
         }
         self.request = Request(**self.request_kwargs)
+        self.certificate_arn = 'arn:aws:acm:us-east-1:123:certificate/1337'
         self.mock_request = patch.object(provider, 'Request').start()
         self.mock_request.return_value = Mock()
         self.mock_response = patch.object(provider, 'Response').start()
@@ -228,18 +230,21 @@ class CertificateValidatorBaseTestCase(AWSBaseTestCase, ProviderBaseTestCase):
         self.mock_change_resource_record_sets = patch.object(
             resources.Route53, 'change_resource_record_sets'
         ).start()
+        self.mock_get_domain_validation_options = patch.object(
+            resources.CertificateValidator, 'get_domain_validation_options'
+        ).start()
+        self.mock_get_domain_validation_options.return_value = [{
+            'DomainName': 'certificate-validator.com',
+            'ResourceRecord': {
+                'Name': '_x1.certificate-validator.com.',
+                'Type': 'CNAME',
+                'Value': '_x2.acm-validations.aws.'
+            }
+        }]
         self.mock_get_hosted_zone_id = patch.object(
             resources.CertificateValidator, 'get_hosted_zone_id'
         ).start()
         self.mock_get_hosted_zone_id.return_value = 'Z23ABC4XYZL05B'
-        self.mock_get_resource_records = patch.object(
-            resources.CertificateValidator, 'get_resource_records'
-        ).start()
-        self.mock_get_resource_records.return_value = [{
-            'Name': '_x1.certificate-validator.com.',
-            'Type': 'CNAME',
-            'Value': '_x2.acm-validations.aws.'
-        }]
         self.mock_get_change_batch = patch.object(
             resources.CertificateValidator, 'get_change_batch'
         ).start()

--- a/certificate_validator/tests/test_resources.py
+++ b/certificate_validator/tests/test_resources.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-'''Tests for the `resources` module.'''
+"""Tests for the `resources` module."""
 
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from botocore import exceptions
 
@@ -83,10 +83,8 @@ class CertificateTestCase(CertificateBaseTestCase):
     def test_update(self):
         c = Certificate(self.request, self.response)
         mock_create = patch.object(c, 'create').start()
-        mock_delete = patch.object(c, 'delete').start()
         c.update()
         mock_create.assert_called_once()
-        mock_delete.assert_called_once()
 
     def test_delete_success_certificate_does_not_exist(self):
         self.mock_request.physical_resource_id = ''
@@ -147,150 +145,197 @@ class CertificateValidatorTestCase(CertificateValidatorBaseTestCase):
         self.assertEqual(self.request, cv.request)
         self.assertEqual(self.response, cv.response)
 
-    def test_create_failed_certificate_arn_is_invalid(self):
-        self.mock_request.resource_properties = {'CertificateArn': 'invalid'}
+    def test_change_resource_record_sets_failed_certificate_arn_is_invalid(
+        self
+    ):
         cv = CertificateValidator(self.mock_request, self.mock_response)
-        cv.create()
+        cv.change_resource_record_sets('invalid', Action.CREATE)
         self.mock_response.set_status.assert_called_with(success=False)
         self.mock_response.set_reason.assert_called_with(
             reason='Certificate ARN is invalid.'
         )
 
-    def test_create_success(self):
+    def test_change_resource_record_sets_create_success(self):
         self.mock_request.resource_properties = {
-            'CertificateArn': 'arn:aws:acm:us-east-1:123:certificate/1337'
+            'CertificateArn': self.certificate_arn
         }
         cv = CertificateValidator(self.mock_request, self.mock_response)
+        cv.change_resource_record_sets(self.certificate_arn, Action.CREATE)
+        self.mock_get_hosted_zone_id.assert_called_with(
+            'certificate-validator.com'
+        )
+        self.mock_get_domain_validation_options.assert_called_with(
+            'arn:aws:acm:us-east-1:123:certificate/1337'
+        )
+        self.mock_get_change_batch.assert_called_with(
+            'CREATE', {
+                'Name': '_x1.certificate-validator.com.',
+                'Type': 'CNAME',
+                'Value': '_x2.acm-validations.aws.'
+            }
+        )
+        self.mock_change_resource_record_sets.assert_called_with(
+            hosted_zone_id='Z23ABC4XYZL05B',
+            change_batch={
+                'Changes': {
+                    'ResourceRecordSet': {
+                        'Name': '_x1.certificate-validator.com.',
+                        'Type': 'CNAME',
+                        'TTL': 300,
+                        'ResourceRecords': [{
+                            'Value': '_x2.acm-validations.aws.'
+                        }]
+                    }
+                }
+            }
+        )
+        self.mock_response.set_status.assert_called_with(success=True)
+
+    def test_change_resource_record_sets_create_failed(self):
+        self.mock_request.resource_properties = {
+            'CertificateArn': self.certificate_arn
+        }
+        self.mock_get_domain_validation_options.side_effect = \
+            exceptions.ClientError(
+                error_response={'Error': {
+                    'Code': '1337',
+                    'Message': 'Message'
+                }},
+                operation_name='Operation'
+            )
+        cv = CertificateValidator(self.mock_request, self.mock_response)
+        cv.change_resource_record_sets(self.certificate_arn, Action.CREATE)
+        self.mock_response.set_status.assert_called_with(success=False)
+        reason = \
+            'An error occurred (1337) when calling the Operation operation: ' \
+            'Message'
+        self.mock_response.set_reason.assert_called_with(reason=reason)
+
+    def test_change_resource_record_sets_upsert(self):
+        self.mock_request.resource_properties = {
+            'CertificateArn': self.certificate_arn
+        }
+        cv = CertificateValidator(self.mock_request, self.mock_response)
+        cv.change_resource_record_sets(self.certificate_arn, Action.UPSERT)
+        self.mock_get_hosted_zone_id.assert_called_with(
+            'certificate-validator.com'
+        )
+        self.mock_get_domain_validation_options.assert_called_with(
+            'arn:aws:acm:us-east-1:123:certificate/1337'
+        )
+        self.mock_get_change_batch.assert_called_with(
+            'UPSERT', {
+                'Name': '_x1.certificate-validator.com.',
+                'Type': 'CNAME',
+                'Value': '_x2.acm-validations.aws.'
+            }
+        )
+        self.mock_change_resource_record_sets.assert_called_with(
+            hosted_zone_id='Z23ABC4XYZL05B',
+            change_batch={
+                'Changes': {
+                    'ResourceRecordSet': {
+                        'Name': '_x1.certificate-validator.com.',
+                        'Type': 'CNAME',
+                        'TTL': 300,
+                        'ResourceRecords': [{
+                            'Value': '_x2.acm-validations.aws.'
+                        }]
+                    }
+                }
+            }
+        )
+        self.mock_response.set_status.assert_called_with(success=True)
+
+    def test_change_resource_record_sets_delete_success(self):
+        self.mock_request.resource_properties = {
+            'CertificateArn': self.certificate_arn
+        }
+        cv = CertificateValidator(self.mock_request, self.mock_response)
+        cv.change_resource_record_sets(self.certificate_arn, Action.DELETE)
+        self.mock_get_hosted_zone_id.assert_called_with(
+            'certificate-validator.com'
+        )
+        self.mock_get_domain_validation_options.assert_called_with(
+            'arn:aws:acm:us-east-1:123:certificate/1337'
+        )
+        self.mock_get_change_batch.assert_called_with(
+            'DELETE', {
+                'Name': '_x1.certificate-validator.com.',
+                'Type': 'CNAME',
+                'Value': '_x2.acm-validations.aws.'
+            }
+        )
+        self.mock_change_resource_record_sets.assert_called_with(
+            hosted_zone_id='Z23ABC4XYZL05B',
+            change_batch={
+                'Changes': {
+                    'ResourceRecordSet': {
+                        'Name': '_x1.certificate-validator.com.',
+                        'Type': 'CNAME',
+                        'TTL': 300,
+                        'ResourceRecords': [{
+                            'Value': '_x2.acm-validations.aws.'
+                        }]
+                    }
+                }
+            }
+        )
+        self.mock_response.set_status.assert_called_with(success=True)
+
+    def test_change_resource_record_sets_delete_failed(self):
+        self.mock_request.resource_properties = {
+            'CertificateArn': self.certificate_arn
+        }
+        self.mock_get_domain_validation_options.side_effect = \
+            exceptions.ClientError(
+                error_response={'Error': {
+                    'Code': '1337',
+                    'Message': 'Message'
+                }},
+                operation_name='Operation'
+            )
+        cv = CertificateValidator(self.mock_request, self.mock_response)
+        cv.change_resource_record_sets(self.certificate_arn, Action.DELETE)
+        self.mock_response.set_status.assert_called_with(success=False)
+        reason = \
+            'An error occurred (1337) when calling the Operation operation: ' \
+            'Message'
+        self.mock_response.set_reason.assert_called_with(reason=reason)
+
+    def test_create(self):
+        mock_change_resource_record_sets = \
+            patch.object(resources.CertificateValidator,
+                         'change_resource_record_sets').start()
+        cv = CertificateValidator(self.request, self.mock_response)
         cv.create()
         self.mock_response.set_physical_resource_id.assert_called_with('1337')
-        self.mock_describe_certificate.assert_called_with(
-            certificate_arn='arn:aws:acm:us-east-1:123:certificate/1337'
+        mock_change_resource_record_sets.assert_called_with(
+            'arn:aws:acm:us-east-1:123:certificate/1', Action.UPSERT
         )
-        self.mock_get_hosted_zone_id.assert_called_with(
-            'certificate-validator.com'
-        )
-        self.mock_get_resource_records.assert_called_with(
-            'arn:aws:acm:us-east-1:123:certificate/1337'
-        )
-        self.mock_get_change_batch.assert_called_with(
-            'CREATE', [{
-                'Name': '_x1.certificate-validator.com.',
-                'Type': 'CNAME',
-                'Value': '_x2.acm-validations.aws.'
-            }]
-        )
-        self.mock_change_resource_record_sets.assert_called_with(
-            hosted_zone_id='Z23ABC4XYZL05B',
-            change_batch={
-                'Changes': {
-                    'ResourceRecordSet': {
-                        'Name': '_x1.certificate-validator.com.',
-                        'Type': 'CNAME',
-                        'TTL': 300,
-                        'ResourceRecords': [{
-                            'Value': '_x2.acm-validations.aws.'
-                        }]
-                    }
-                }
-            }
-        )
-        self.mock_response.set_status.assert_called_with(success=True)
-
-    def test_create_failed(self):
-        self.mock_request.resource_properties = {
-            'CertificateArn': 'arn:aws:acm:us-east-1:123:certificate/1337'
-        }
-        self.mock_describe_certificate.side_effect = exceptions.ClientError(
-            error_response={'Error': {
-                'Code': '1337',
-                'Message': 'Message'
-            }},
-            operation_name='Operation'
-        )
-        cv = CertificateValidator(self.mock_request, self.mock_response)
-        cv.create()
-        self.mock_response.set_status.assert_called_with(success=False)
-        reason = \
-            'An error occurred (1337) when calling the Operation operation: ' \
-            'Message'
-        self.mock_response.set_reason.assert_called_with(reason=reason)
 
     def test_update(self):
-        cv = CertificateValidator(self.request, self.response)
-        mock_create = patch.object(cv, 'create').start()
-        mock_delete = patch.object(cv, 'delete').start()
+        mock_change_resource_record_sets = \
+            patch.object(resources.CertificateValidator,
+                         'change_resource_record_sets').start()
+        cv = CertificateValidator(self.request, self.mock_response)
         cv.update()
-        mock_create.assert_called_once()
-        mock_delete.assert_called_once()
+        mock_change_resource_record_sets.assert_has_calls([
+            call('arn:aws:acm:us-east-1:123:certificate/0', Action.DELETE),
+            call('arn:aws:acm:us-east-1:123:certificate/1', Action.UPSERT)
+        ])
 
-    def test_delete_failed_certificate_arn_is_invalid(self):
-        self.mock_request.resource_properties = {'CertificateArn': 'invalid'}
-        cv = CertificateValidator(self.mock_request, self.mock_response)
+    def test_delete(self):
+        mock_change_resource_record_sets = \
+            patch.object(resources.CertificateValidator,
+                         'change_resource_record_sets').start()
+        cv = CertificateValidator(self.request, self.mock_response)
         cv.delete()
-        self.mock_response.set_status.assert_called_with(success=False)
-        self.mock_response.set_reason.assert_called_with(
-            reason='Certificate ARN is invalid.'
+        mock_change_resource_record_sets.assert_called_with(
+            'arn:aws:acm:us-east-1:123:certificate/1', Action.DELETE
         )
 
-    def test_delete_success(self):
-        self.mock_request.resource_properties = {
-            'CertificateArn': 'arn:aws:acm:us-east-1:123:certificate/1337'
-        }
-        cv = CertificateValidator(self.mock_request, self.mock_response)
-        cv.delete()
-        self.mock_describe_certificate.assert_called_with(
-            certificate_arn='arn:aws:acm:us-east-1:123:certificate/1337'
-        )
-        self.mock_get_hosted_zone_id.assert_called_with(
-            'certificate-validator.com'
-        )
-        self.mock_get_resource_records.assert_called_with(
-            'arn:aws:acm:us-east-1:123:certificate/1337'
-        )
-        self.mock_get_change_batch.assert_called_with(
-            'DELETE', [{
-                'Name': '_x1.certificate-validator.com.',
-                'Type': 'CNAME',
-                'Value': '_x2.acm-validations.aws.'
-            }]
-        )
-        self.mock_change_resource_record_sets.assert_called_with(
-            hosted_zone_id='Z23ABC4XYZL05B',
-            change_batch={
-                'Changes': {
-                    'ResourceRecordSet': {
-                        'Name': '_x1.certificate-validator.com.',
-                        'Type': 'CNAME',
-                        'TTL': 300,
-                        'ResourceRecords': [{
-                            'Value': '_x2.acm-validations.aws.'
-                        }]
-                    }
-                }
-            }
-        )
-        self.mock_response.set_status.assert_called_with(success=True)
-
-    def test_delete_failed(self):
-        self.mock_request.resource_properties = {
-            'CertificateArn': 'arn:aws:acm:us-east-1:123:certificate/1337'
-        }
-        self.mock_describe_certificate.side_effect = exceptions.ClientError(
-            error_response={'Error': {
-                'Code': '1337',
-                'Message': 'Message'
-            }},
-            operation_name='Operation'
-        )
-        cv = CertificateValidator(self.mock_request, self.mock_response)
-        cv.delete()
-        self.mock_response.set_status.assert_called_with(success=False)
-        reason = \
-            'An error occurred (1337) when calling the Operation operation: ' \
-            'Message'
-        self.mock_response.set_reason.assert_called_with(reason=reason)
-
-    def test_get_resource_records(self):
+    def test_get_domain_validation_options(self):
         patch.stopall()
         mock_describe_certificate = patch.object(
             resources.ACM, 'describe_certificate'
@@ -299,6 +344,7 @@ class CertificateValidatorTestCase(CertificateValidatorBaseTestCase):
             'Certificate': {
                 'DomainName': 'certificate-validator.com',
                 'DomainValidationOptions': [{
+                    'DomainName': 'certificate-validator.com',
                     'ResourceRecord': {
                         'Name': '_x1.certificate-validator.com.',
                         'Type': 'CNAME',
@@ -308,17 +354,20 @@ class CertificateValidatorTestCase(CertificateValidatorBaseTestCase):
             }
         }
         cv = CertificateValidator(self.request, self.response)
-        actual = cv.get_resource_records(
+        actual = cv.get_domain_validation_options(
             certificate_arn='arn:aws:acm:us-east-1:123:certificate/1337'
         )
         expected = [{
-            'Name': '_x1.certificate-validator.com.',
-            'Type': 'CNAME',
-            'Value': '_x2.acm-validations.aws.'
+            'DomainName': 'certificate-validator.com',
+            'ResourceRecord': {
+                'Name': '_x1.certificate-validator.com.',
+                'Type': 'CNAME',
+                'Value': '_x2.acm-validations.aws.'
+            }
         }]
         self.assertEqual(expected, actual)
 
-    def test_get_resource_records_poll(self):
+    def test_get_domain_validation_options_poll(self):
         patch.stopall()
         patch('time.sleep', return_value=None).start()
         mock_describe_certificate = patch.object(
@@ -345,13 +394,16 @@ class CertificateValidatorTestCase(CertificateValidatorBaseTestCase):
             }
         }]
         cv = CertificateValidator(self.request, self.response)
-        actual = cv.get_resource_records(
+        actual = cv.get_domain_validation_options(
             certificate_arn='arn:aws:acm:us-east-1:123:certificate/1337'
         )
         expected = [{
-            'Name': '_x1.certificate-validator.com.',
-            'Type': 'CNAME',
-            'Value': '_x2.acm-validations.aws.'
+            'DomainName': 'certificate-validator.com',
+            'ResourceRecord': {
+                'Name': '_x1.certificate-validator.com.',
+                'Type': 'CNAME',
+                'Value': '_x2.acm-validations.aws.'
+            }
         }]
         self.assertEqual(expected, actual)
 
@@ -374,13 +426,13 @@ class CertificateValidatorTestCase(CertificateValidatorBaseTestCase):
     def test_get_change_batch(self):
         patch.stopall()
         cv = CertificateValidator(self.request, self.response)
-        resource_records = [{
+        resource_record = {
             'Name': '_x1.certificate-validator.com.',
             'Type': 'CNAME',
             'Value': '_x2.acm-validations.aws.'
-        }]
+        }
         actual = cv.get_change_batch(
-            action='CREATE', resource_records=resource_records
+            action='CREATE', resource_record=resource_record
         )
         expected = {
             'Changes': [{


### PR DESCRIPTION
 - The CertificateValidator custom resource can now handle subject alternative
   names in multiple hosted zones
 - The CertificateValidator custom resource will now remove the CNAME records
   for subject alternative names that are removed from the Certificate custom
   resource