### PR TITLE
Updates

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,12 @@
 # History
 
+## v???
+
+* Deploy certificate to same region as CloudFormation stack
+* Allow Setting Log Level from CloudFormation Stack
+* Do not fail if SubjectAlternativeNames is an empty list. Support empty items
+  in SubjectAlternativeNames list.
+
 ## v0.4.1 (2019-09-19)
 ---
 

--- a/certificate_validator/certificate_validator/__init__.py
+++ b/certificate_validator/certificate_validator/__init__.py
@@ -2,6 +2,7 @@
 """Top-level package for certificate_validator."""
 
 from . import version
+
 __author__ = version.author
 __email__ = version.email
 __version__ = version.version

--- a/certificate_validator/certificate_validator/__init__.py
+++ b/certificate_validator/certificate_validator/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Top-level package for certificate_validator."""
 
-__author__ = """Nickolas Kraus"""
-__email__ = 'NickHKraus@gmail.com'
-__version__ = '0.4.1'
+from . import version
+__author__ = version.author
+__email__ = version.email
+__version__ = version.version

--- a/certificate_validator/certificate_validator/api.py
+++ b/certificate_validator/certificate_validator/api.py
@@ -102,8 +102,10 @@ class ACM(AWS):
         :rtype: dict
         :return: ARN of the issued certificate
         """
-        kwargs = dict(DomainName=domain_name,
-                      ValidationMethod=ValidationMethod.DNS.value)
+        kwargs = dict(
+            DomainName=domain_name,
+            ValidationMethod=ValidationMethod.DNS.value
+        )
         if subject_alternative_names:
             kwargs['SubjectAlternativeNames'] = subject_alternative_names
         return self.client.request_certificate(**kwargs)

--- a/certificate_validator/certificate_validator/api.py
+++ b/certificate_validator/certificate_validator/api.py
@@ -102,11 +102,11 @@ class ACM(AWS):
         :rtype: dict
         :return: ARN of the issued certificate
         """
-        return self.client.request_certificate(
-            DomainName=domain_name,
-            SubjectAlternativeNames=subject_alternative_names,
-            ValidationMethod=ValidationMethod.DNS.value
-        )
+        kwargs = dict(DomainName=domain_name, 
+                      ValidationMethod=ValidationMethod.DNS.value)
+        if subject_alternative_names:
+            kwargs['SubjectAlternativeNames'] = subject_alternative_names
+        return self.client.request_certificate(**kwargs)
 
     def delete_certificate(self, certificate_arn: str) -> None:
         """

--- a/certificate_validator/certificate_validator/api.py
+++ b/certificate_validator/certificate_validator/api.py
@@ -102,7 +102,7 @@ class ACM(AWS):
         :rtype: dict
         :return: ARN of the issued certificate
         """
-        kwargs = dict(DomainName=domain_name, 
+        kwargs = dict(DomainName=domain_name,
                       ValidationMethod=ValidationMethod.DNS.value)
         if subject_alternative_names:
             kwargs['SubjectAlternativeNames'] = subject_alternative_names

--- a/certificate_validator/certificate_validator/data_mapper.py
+++ b/certificate_validator/certificate_validator/data_mapper.py
@@ -1,0 +1,94 @@
+"""
+Data Mapper class.
+"""
+
+
+class DataMapperValue:
+    """
+    Data Mapper Value.
+    """
+    def __init__(self, param: str, default='', parser=None):
+        """
+        Construct Data Mapper Value.
+        """
+        self.param = param
+        self.default = default
+        self._parser = parser
+
+    def parsed(self, value):
+        """
+        Return Parsed Value.
+        """
+        if self._parser and callable(self._parser):
+            return self._parser(value)
+        return value
+
+
+class CleanListValue(DataMapperValue):
+    """
+    Clean List Data Mapper Value.
+    """
+    def __init__(self, param, invalid_values=None):
+        """
+        Construct Clean List Data Mapper Value Definition.
+        """
+        super().__init__(param)
+        self.invalid_values = invalid_values if invalid_values else [
+            None, '', '-'
+        ]
+
+    def parsed(self, value):
+        """
+        Parse Value.
+        """
+        if not value:
+            value = []
+        return [item for item in value if item not in self.invalid_values]
+
+
+class ClassValue(DataMapperValue):
+    """
+    Data Mapper Value that expects a child DataMapper class as value.
+    """
+    def __init__(self, param, clazz, default=None):
+        """
+        Construct Class Data Mapper Value.
+        """
+        super().__init__(param, default=default)
+        self.clazz = clazz
+
+    def parsed(self, value):
+        """
+        Parse Value.
+        """
+        if not value:
+            value = {}
+        return self.clazz(**value)
+
+
+class DataMapper:
+    """
+    Base class for data mapped classes.
+    """
+    MAP = {}
+
+    def __init__(self, **kwargs):
+        """
+        Construct a data map from a dictionary.
+        """
+        data = {}
+
+        # Add Defaults
+        for param_name, param in self.MAP.items():
+            data[param_name] = param.default
+
+        # add values
+        data.update(kwargs)
+
+        # Load parameters
+        for param_name, value in data.items():
+            param = self.MAP.get(param_name, None)
+            if param and isinstance(param, DataMapperValue):
+                param_name = param.param
+                value = param.parsed(value)
+            self.__dict__[param_name] = value

--- a/certificate_validator/certificate_validator/logger.py
+++ b/certificate_validator/certificate_validator/logger.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+"""
+Shared Logger Module.
+
+Placing it here to allow unified logging controls across modules
+"""
+
+import logging
+
+logger = logging.getLogger('certificate_validator')
+logger.setLevel(logging.DEBUG)

--- a/certificate_validator/certificate_validator/main.py
+++ b/certificate_validator/certificate_validator/main.py
@@ -3,11 +3,9 @@
 
 import logging
 
+from certificate_validator.logger import logger
 from certificate_validator.provider import Request, Response
 from certificate_validator.resources import Certificate, CertificateValidator
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
 
 
 def handler(event: dict, context: object) -> dict:

--- a/certificate_validator/certificate_validator/main.py
+++ b/certificate_validator/certificate_validator/main.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 """Main AWS Lambda function module."""
 
-import logging
-
 from certificate_validator.logger import logger
 from certificate_validator.provider import Request, Response
 from certificate_validator.resources import Certificate, CertificateValidator
+
+DEFAULT_LOG_LEVEL = 'INFO'
 
 
 def handler(event: dict, context: object) -> dict:
@@ -17,7 +17,11 @@ def handler(event: dict, context: object) -> dict:
     :param context: runtime information of the AWS Lambda function
     :type context: LambdaContext object
     """
-    logger.debug('Request: {}'.format(event))
+    # Set log level manually before anything else
+    props = event.get('ResourceProperties', {})
+    logger.setLevel(props.get('LogLevel', DEFAULT_LOG_LEVEL))
+
+    logger.debug('Request: %s', event)
 
     request = Request(**event)
 
@@ -31,11 +35,9 @@ def handler(event: dict, context: object) -> dict:
     if request.resource_type == 'Custom::Certificate':
         certificate = Certificate(request, response)
         certificate.handler()
-        logger.debug('Response: {}'.format(certificate.response.dict()))
+        logger.debug('Response: %s', certificate.response.dict())
 
     if request.resource_type == 'Custom::CertificateValidator':
         certificate_validator = CertificateValidator(request, response)
         certificate_validator.handler()
-        logger.debug(
-            'Response: {}'.format(certificate_validator.response.dict())
-        )
+        logger.debug('Response: %s', certificate_validator.response.dict())

--- a/certificate_validator/certificate_validator/main.py
+++ b/certificate_validator/certificate_validator/main.py
@@ -4,6 +4,7 @@
 from certificate_validator.logger import logger
 from certificate_validator.provider import Request, Response
 from certificate_validator.resources import Certificate, CertificateValidator
+from certificate_validator.version import version
 
 DEFAULT_LOG_LEVEL = 'INFO'
 
@@ -21,6 +22,7 @@ def handler(event: dict, context: object) -> dict:
     props = event.get('ResourceProperties', {})
     logger.setLevel(props.get('LogLevel', DEFAULT_LOG_LEVEL))
 
+    logger.info('Starting certificate-validator v%s', version)
     logger.debug('Request: %s', event)
 
     request = Request(**event)

--- a/certificate_validator/certificate_validator/version.py
+++ b/certificate_validator/certificate_validator/version.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+"""Top-level package for certificate_validator."""
+
+author = """Nickolas Kraus"""
+email = 'NickHKraus@gmail.com'
+version = '0.4.2a'

--- a/certificate_validator/certificate_validator/version.py
+++ b/certificate_validator/certificate_validator/version.py
@@ -3,4 +3,4 @@
 
 author = """Nickolas Kraus"""
 email = 'NickHKraus@gmail.com'
-version = '0.4.2a'
+version = '0.4.1'

--- a/certificate_validator/setup.cfg
+++ b/certificate_validator/setup.cfg
@@ -3,9 +3,9 @@ current_version = 0.4.1
 commit = True
 tag = False
 
-[bumpversion:file:certificate_validator/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
+[bumpversion:file:certificate_validator/version.py]
+search = version = '{current_version}'
+replace = version = '{new_version}'
 
 [coverage:run]
 branch = True

--- a/certificate_validator/tests/base.py
+++ b/certificate_validator/tests/base.py
@@ -4,7 +4,7 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from certificate_validator import api, main, provider, resources
+from certificate_validator import api, logger, main, provider, resources
 from certificate_validator.api import AWS
 from certificate_validator.provider import Provider, Request, Response
 
@@ -28,7 +28,7 @@ class AWSBaseTestCase(BaseTestCase):
 class MainBaseTestCase(BaseTestCase):
     def setUp(self):
         super(MainBaseTestCase, self).setUp()
-        self.mock_logging = patch.object(main.logging, 'getLogger').start()
+        self.mock_logging = patch.object(logger.logging, 'getLogger').start()
         self.mock_logging.return_value = Mock()
         self.mock_logger = patch.object(main, 'logger').start()
         self.event = {
@@ -83,6 +83,7 @@ class RequestBaseTestCase(BaseTestCase):
                 'ServiceToken': 'service_token'
             }
         }
+        self.mock_logger = patch.object(provider, 'logger').start()
         self.request = Request(**self.kwargs)
 
 

--- a/certificate_validator/tests/test_api.py
+++ b/certificate_validator/tests/test_api.py
@@ -53,6 +53,18 @@ class ACMTestCase(AWSBaseTestCase):
         )
         self.assertEqual(expected, actual)
 
+    def test_request_certificate_no_san(self):
+        expected = {'CertificateArn': 'string'}
+        self.acm.client.request_certificate.return_value = {
+            'CertificateArn': 'string'
+        }
+        actual = self.acm.request_certificate('example.com', [])
+        self.acm.client.request_certificate.assert_called_with(
+            DomainName='example.com',
+            ValidationMethod='DNS'
+        )
+        self.assertEqual(expected, actual)
+
     def test_delete_certificate(self):
         certificate_arn = \
             'arn:aws:acm:region:account-id:certificate/certificate-id'

--- a/certificate_validator/tests/test_api.py
+++ b/certificate_validator/tests/test_api.py
@@ -60,8 +60,7 @@ class ACMTestCase(AWSBaseTestCase):
         }
         actual = self.acm.request_certificate('example.com', [])
         self.acm.client.request_certificate.assert_called_with(
-            DomainName='example.com',
-            ValidationMethod='DNS'
+            DomainName='example.com', ValidationMethod='DNS'
         )
         self.assertEqual(expected, actual)
 

--- a/certificate_validator/tests/test_data_mapper.py
+++ b/certificate_validator/tests/test_data_mapper.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+"""Tests for the `provider` module."""
+
+from unittest.mock import Mock
+
+from certificate_validator.data_mapper import (
+    ClassValue, CleanListValue, DataMapper, DataMapperValue
+)
+
+from .base import BaseTestCase
+
+
+class CustomDataMapper(DataMapper):
+
+    MAP = {
+        'ValueDefault': DataMapperValue('value_default', default="default"),
+        'ValueEmpty': DataMapperValue('value_empty', default=""),
+        'ValueNoDefault': DataMapperValue('value_no_default', default=""),
+        'ValueNone': DataMapperValue('value_none', default=None)
+    }
+
+
+class DataMapperValueTestCase(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+    def test_data_mapper_value_default_and_parser(self):
+        parser = Mock()
+        parser.return_value = 'return_value'
+        value = DataMapperValue(
+            'value_default', default="default", parser=parser
+        )
+        self.assertEquals('value_default', value.param)
+        self.assertEquals('default', value.default)
+        parser.assert_not_called()
+        self.assertEquals('return_value', value.parsed('custom'))
+        parser.assert_called_once_with('custom')
+
+    def test_data_mapper_value_default_and_no_parser(self):
+        value = DataMapperValue('value_default', default="default")
+        self.assertEquals('value_default', value.param)
+        self.assertEquals('default', value.default)
+        self.assertEquals('custom', value.parsed('custom'))
+
+    def test_data_mapper_value_no_default_and_no_parser(self):
+        value = DataMapperValue('value_default')
+        self.assertEquals('value_default', value.param)
+        self.assertEquals('', value.default)
+        self.assertEquals('custom', value.parsed('custom'))
+
+    def test_data_mapper_value_none_default_and_no_parser(self):
+        value = DataMapperValue('value_default', default=None)
+        self.assertEquals('value_default', value.param)
+        self.assertIsNone(value.default)
+        self.assertEquals('custom', value.parsed('custom'))
+
+
+class CleanListValueTestCase(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+    def test_empty_default(self):
+        test_cases = [
+            (None, []),
+            ([], []),
+            ([None], []),
+            ([''], []),
+            (['-'], []),
+            ([None, ''], []),
+            ([None, '-'], []),
+            ([None, '', '-'], []),
+        ]
+
+        value = CleanListValue('value')
+
+        for test_case, expected in test_cases:
+            actual = value.parsed(test_case)
+            self.assertEqual(
+                expected, actual,
+                "Failed clean_list({}) - expected {}, got {}".format(
+                    test_case, expected, actual
+                )
+            )
+
+    def test_non_empty_default(self):
+        test_cases = [
+            ([None, 'value'], ['value']),
+            (['value'], ['value']),
+            (['value', None], ['value']),
+            (['', 'value'], ['value']),
+            (['value', ''], ['value']),
+            (['-', 'value'], ['value']),
+            (['value', '-'], ['value']),
+            ([None, 'value', ''], ['value']),
+            ([None, 'value', '-'], ['value']),
+            ([None, 'value', '', '-'], ['value']),
+        ]
+
+        value = CleanListValue('value')
+
+        for test_case, expected in test_cases:
+            actual = value.parsed(test_case)
+            self.assertEqual(
+                expected, actual,
+                "Failed clean_list({}) - expected {}, got {}".format(
+                    test_case, expected, actual
+                )
+            )
+
+
+class ClassValueTestCase(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+    def test_empty(self):
+        value = ClassValue('value', clazz=CustomDataMapper)
+        parsed = value.parsed({})
+        self.assertIsInstance(parsed, CustomDataMapper)
+        self.assertEqual(parsed.value_default, 'default')
+        self.assertEqual(parsed.value_empty, '')
+        self.assertEqual(parsed.value_no_default, '')
+        self.assertIsNone(parsed.value_none)
+
+    def test_values(self):
+        value = ClassValue('value', clazz=CustomDataMapper)
+        parsed = value.parsed({
+            'extra': value,
+            'ValueDefault': 'ValueDefault',
+            'ValueEmpty': 'ValueEmpty',
+        })
+        self.assertIsInstance(parsed, CustomDataMapper)
+        self.assertEqual(parsed.value_default, 'ValueDefault')
+        self.assertEqual(parsed.value_empty, 'ValueEmpty')
+        self.assertEqual(parsed.value_no_default, '')
+        self.assertIsNone(parsed.value_none)

--- a/docs/certificate-validator.md
+++ b/docs/certificate-validator.md
@@ -21,6 +21,16 @@ Properties:
 
 ## Properties
 
+### `LogLevel`
+
+Log Level for Lambda Function output
+
+One of: DEBUG, INFO, WARNING, ERROR, CRITICAL
+
+*Default*: INFO
+*Required*: No
+*Type*: String
+
 ### `ServiceToken`
 
 >**Note**

--- a/docs/certificate.md
+++ b/docs/certificate.md
@@ -25,6 +25,16 @@ Properties:
 
 ## Properties
 
+### `LogLevel`
+
+Log Level for Lambda Function output
+
+One of: DEBUG, INFO, WARNING, ERROR, CRITICAL
+
+*Default*: INFO
+*Required*: No
+*Type*: String
+
 ### `ServiceToken`
 
 >**Note**


### PR DESCRIPTION
Mostly some fixes I added for my own use, but figure I'd share them back

* Deploy certificate to same region as CloudFormation stack (previously seems to be hardcoded)
* Allow Setting Log Level from CloudFormation Stack/Reduce default log level
* Do not fail if SubjectAlternativeNames is an empty list. Support empty items
  in SubjectAlternativeNames list. (previously i got errors if SAN list was empty)
 